### PR TITLE
Added cache contexts to the theme.

### DIFF
--- a/byu_theme.theme
+++ b/byu_theme.theme
@@ -35,6 +35,9 @@ function byu_theme_preprocess_page(&$variables) {
   $path_args = explode('/', $current_path);
   $variables['arg'] = $path_args[1];
 
+  //setting proper cache context for users
+  $variables['#cache']['contexts'][] = 'user';
+
   $version = trim(theme_get_setting('components_version'));
   if(!empty($version ) ) {
 


### PR DESCRIPTION
This change fixes a bug that incorrectly displayed the wrong usernames in the header. The theme failed to specify cache context, so the first user to log into a page was displayed for all subsequent users until the cache refreshed. Now it respects the user cache.